### PR TITLE
add support for float images

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,7 +90,10 @@ export class PythonOpencvImageProvider implements vscode.CodeActionProvider {
 
 		let path = join(this.workingdir,  `${targetVariable.name}.png`);
 		let savepath = path.replace(/\\/g, '/');
-		const expression = `cv2.imwrite('${savepath}', ${targetVariable.evaluateName})`;
+
+		const vn = targetVariable.evaluateName; // var name
+		const float_expression =  `${vn} * 255.0 if (${vn}.dtype == np.float64 or ${vn}.dtype == np.float32) else ${vn}`;
+		const expression = `cv2.imwrite('${savepath}', ${float_expression})`;
 		res = await session.customRequest("evaluate", { expression: expression, frameId: callStack, context:'hover' });
 		console.log(`evaluate ${expression} result: ${res.result}`);
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -8,7 +8,7 @@ const path = require('path');
 const config = {
   target: 'node', // vscode extensions run in a Node.js-context 📖 -> https://webpack.js.org/configuration/node/
 
-  entry: '.\\src\\extension.ts', // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/
+  entry: './src/extension.ts', // the entry point of this extension, 📖 -> https://webpack.js.org/configuration/entry-context/
   output: {
     // the bundle is stored in the 'dist' folder (check package.json), 📖 -> https://webpack.js.org/configuration/output/
     path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
please check webpack.config.js file changes, im not sure why it was '\\' before
I added a check if the image is float:
``const float_expression =  `img * 255.0 if (img.dtype == np.float64 or img.dtype == np.float32) else img`;``